### PR TITLE
Adds jest-test-runner

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -53,7 +53,8 @@
 				"ms-python.pylint",
 				"ms-python.mypy-type-checker",
 				"matangover.mypy",
-				"ms-toolsai.jupyter"
+				"ms-toolsai.jupyter",
+				"firsttris.vscode-jest-runner"
 			]
 		}
 	}


### PR DESCRIPTION
Closes issue #20 

The run prompts above tests can be used to run groups or individual tests in Jest.

Extension added:
https://marketplace.visualstudio.com/items?itemName=firsttris.vscode-jest-runner