### PR TITLE
feat: enable full logging of test failure reasons

### DIFF
--- a/java-spring-boot/build.gradle
+++ b/java-spring-boot/build.gradle
@@ -33,4 +33,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	testLogging {
+        exceptionFormat "full"
+	}
 }


### PR DESCRIPTION
This shows better output in the console. We go from something like this.

<img width="568" alt="Screenshot 2023-10-31 at 12 35 25 PM" src="https://github.com/sourceallies/interviews/assets/9507268/f6e5412f-5b9f-4a2c-87f8-ce3d560f9523">

To something like this
<img width="933" alt="Screenshot 2023-10-31 at 12 51 47 PM" src="https://github.com/sourceallies/interviews/assets/9507268/0c571ae3-7e7e-4a43-972f-3576e4a40cdf">
