### PR TITLE
chore: upgrade to Java 21

### DIFF
--- a/java-spring-boot/README.md
+++ b/java-spring-boot/README.md
@@ -1,9 +1,9 @@
 # Java Spring Boot Project
 
 ## Tech Stack
-- Java 17
+- Java 21
 - JUnit 5
-- Spring Boot 3.1   
+- Spring Boot 3.2 
     - Web
     - JPA
     - Lombok

--- a/java-spring-boot/build.gradle
+++ b/java-spring-boot/build.gradle
@@ -1,14 +1,14 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.4'
-	id 'io.spring.dependency-management' version '1.1.3'
+	id 'org.springframework.boot' version '3.2.0'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.sourceallies'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	sourceCompatibility = '21'
 }
 
 configurations {

--- a/java/README.md
+++ b/java/README.md
@@ -1,7 +1,7 @@
 # Java Project
 
 ## Tech Stack
-- Java 17
+- Java 21
 - JUnit 5
 - Maven
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
 	<name>Interview Problem</name>
 	<description>Interview Problem with Maven</description>
 	<properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
The [2.7.0 universal base image](https://github.com/devcontainers/images/blob/main/src/universal/history/2.7.0.md) adds Java 21 by default so we're able to utilize it now.