### PR TITLE
add aws + terraform project

### DIFF
--- a/.devcontainer/aws-terraform/devcontainer.json
+++ b/.devcontainer/aws-terraform/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "AWS + Terraform",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"postCreateCommand": "make init",
+	"workspaceFolder": "/workspaces/interviews/aws-terraform",
+	"features": {
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/terraform:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"liveshare.allowGuestDebugControl": true,
+				"liveshare.allowGuestTaskControl": true,
+				"liveshare.languages.allowGuestCommandControl": true,
+				"liveshare.publishWorkspaceInfo": true,
+				"extensions.ignoreRecommendations": true,
+				"workbench.startupEditor": "readme"
+			},
+			"extensions": [
+				"ms-vsliveshare.vsliveshare",
+				"hashicorp.terraform"
+			]
+		}
+	}
+}

--- a/aws-terraform/.gitignore
+++ b/aws-terraform/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+*.tfstate
+*.tfstate.backup

--- a/aws-terraform/.terraform.lock.hcl
+++ b/aws-terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.13.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:r8XNMWWT49eoxxgPk+zGVG1IkWEMkWUr3G53tQ7dVwA=",
+    "zh:033573bcb8f570658f45a449424e30f3a3279621629cb8160db9be4682535587",
+    "zh:0f3498c75b128885bf2e02704b0572f46818186c6582f655b49da156f6034292",
+    "zh:2093c80d1078de757867c65a54da33f9e0cc72deb164b9f149a4380566de5a42",
+    "zh:2c091a5b2d87bccf7d308bd998c83d3e442cf03a4e3672a57973266942668788",
+    "zh:37097b7b1a38561f40360318f7af1cd4f6b101c3ead356d1dd6fcef7904ff90c",
+    "zh:4bafb8d7b3a7d371949b57a96459226641bf41e0827f7020f5db11c4462d92ff",
+    "zh:59393108b19e14b0c66fe860dc9249a52e983879e11b7be65b3e711ee33cb52b",
+    "zh:71fce5ee215395489005a7d8486c369806310a3ad8ff16ac22a8845c03b99d75",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c90a8564f96289a49d647db3774edb79fccdea1f8c2783ed6f4e8de402aa892f",
+    "zh:cef50fa0b84e0a878c5188d60b7d0b491ab17decfe460cfb4cad3662b83c08b7",
+    "zh:d8b26870d827076f94909973a06a7188222e847d20fb86da1574044abc634847",
+    "zh:d9a1cba670f62eb0a12337f3d6e35e683247daf0a8c2b1611a1510ba36b2fcbf",
+    "zh:e56c28760d35627de1d3a6cbad88393dda922be4420a4bcd5afc45a344ae0b02",
+    "zh:f7c3ae5caddcaf6aa781a56a22e2187fef019f073e52d5ea7e994ec6edac273d",
+  ]
+}

--- a/aws-terraform/Makefile
+++ b/aws-terraform/Makefile
@@ -1,0 +1,14 @@
+init:
+	terraform init
+
+verify:
+	tflint
+	terraform test
+
+plan:
+	terraform plan
+
+apply:
+	terraform apply
+
+.PHONY: init verify plan apply

--- a/aws-terraform/README.md
+++ b/aws-terraform/README.md
@@ -1,0 +1,28 @@
+# AWS + Terraform Project
+
+## Tech Stack
+
+- AWS CLI
+- Terraform
+- Docker (Docker in Docker)
+- Python
+
+## Common Commands
+
+- `make init`
+    - initialize terraform
+- `make verify`
+    - lint and test
+- `make plan`
+    - plan changes
+- `make apply`
+    - apply changes
+
+## AWS Credentials
+
+An interviewer will need to:
+
+- create a new IAM user in the sandbox account
+- create a new access key for the new user
+
+Afterwards, run `aws configure` and apply the credentials locally.

--- a/aws-terraform/main.tf
+++ b/aws-terraform/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  required_version = "1.13"
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+#
+# Example EC2 Instance
+#
+
+data "aws_ami" "ubuntu" {
+  owners = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  most_recent = true
+}
+
+resource "aws_instance" "application" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t2.nano"
+
+  tags = {
+    Name = "interview-application"
+  }
+}

--- a/aws-terraform/main.tf
+++ b/aws-terraform/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "1.13"
+  required_version = "~> 1.13"
 }
 
 provider "aws" {


### PR DESCRIPTION
This PR adds a new interview project built around AWS + Terraform. This is particularly useful for candidates with a DevOps and/or heavy AWS background.