### PR TITLE
Unblock Renovate pinning updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,20 @@
   "packageRules": [
     {
       "description": "These exercises are small starter shells, so anything that survives the full devcontainer matrix is good enough to merge unattended, majors included",
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "description": "Pinning rewrites a range or tag to the exact version already resolved, so there is no newly published code to age. Renovate does not attach a releaseTimestamp to pin/pinDigest updates (renovatebot/renovate#40288), and Renovate 42 defaults minimumReleaseAgeBehaviour to timestamp-required, so a missing timestamp leaves renovate/stability-days pending forever",
+      "matchUpdateTypes": ["pin", "pinDigest"],
+      "minimumReleaseAge": null
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Fixes two problems that are stopping Renovate's pinning PRs from ever merging.

## Problem 1: the pin PR is stuck forever

PR #477 ("Pin dependencies") has every real check passing, plus one that never finishes:

```
verify-complete            SUCCESS
renovate/stability-days    PENDING   <- never clears
```

Here is the chain that causes it:

1. Our config says `minimumReleaseAge: 14 days`. That tells Renovate to let a new release sit for two weeks before using it.
2. To measure age, Renovate needs a release date on the package.
3. Renovate 42 changed what happens when there is no date. It used to say "no date, go ahead." Now it says "no date, so assume it is too new."
4. There is an open Renovate bug ([#40288](https://github.com/renovatebot/renovate/issues/40288)) where pin updates never get a release date attached.

So the date is missing, Renovate assumes the update is too new, and it waits. It waits forever, because the date is never going to show up.

The fix is to turn off the age check for pinning only:

```json
{
  "matchUpdateTypes": ["pin", "pinDigest"],
  "minimumReleaseAge": null
}
```

This is safe, and not just a workaround. Pinning does not pull in any new code. It rewrites `^1.2.3` into `1.2.3`, or rewrites `actions/checkout@v7` into the exact commit `v7` already points at. Same code either way. There is no new release to wait on, so there is nothing to age.

The 14-day wait still applies to everything else — real major, minor, and patch upgrades. That is where the protection actually matters.

## Problem 2: pinDigest was missing from automerge

Our automerge list had `pin` and `digest` but not `pinDigest`. Those are three different things to Renovate:

| Type | What it does |
| --- | --- |
| `pin` | `^1.2.3` becomes `1.2.3` |
| `pinDigest` | `actions/checkout@v7` becomes a commit hash |
| `digest` | an already-pinned hash moves to a newer one |

`pinDigest` is the one that pins GitHub Actions to hashes. Without it in the list, every one of those PRs would wait on a human even after problem 1 was fixed. Added it.

## What changed

| Before | After |
| --- | --- |
| automerge: `major, minor, patch, pin, digest` | adds `pinDigest` |
| age check applies to pins | pins skip the age check |
| `renovate/stability-days` pending forever | clears |

## For the reviewer

- No application code changes. Config only.
- Checked with Renovate's official validator, `--strict`, and it passed.
- After this merges, #477 should go green and merge itself on Renovate's next run.
- The same fix is going up on `yardstick`, which has both bugs for the same reason.
