### PR TITLE
Group vite with its @vitejs plugins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,11 @@
       "automerge": true
     },
     {
+      "description": "@vitejs/* plugins declare a hard peer dependency on the matching vite major, but they ship from vitejs/vite-plugin-react rather than vitejs/vite, so Renovate's monorepo presets group by source repo and never pair them. Split across two PRs, whichever lands first fails npm ci on an ERESOLVE peer conflict",
+      "matchPackageNames": ["vite", "@vitejs/**"],
+      "groupName": "vite"
+    },
+    {
       "description": "Pinning rewrites a range or tag to the exact version already resolved, so there is no newly published code to age. Renovate does not attach a releaseTimestamp to pin/pinDigest updates (renovatebot/renovate#40288), and Renovate 42 defaults minimumReleaseAgeBehaviour to timestamp-required, so a missing timestamp leaves renovate/stability-days pending forever",
       "matchUpdateTypes": ["pin", "pinDigest"],
       "minimumReleaseAge": null


### PR DESCRIPTION
## What's wrong

Renovate opened #486 to upgrade `@vitejs/plugin-react` from 5 to 6. It failed to build, and it will keep failing no matter how many times we retry it.

Here's why. Version 6 of that plugin has a **peer dependency** on vite:

```
peerDependencies = { vite: '^8.0.0' }
```

A peer dependency is a package saying "I don't install this myself, but I only work if you already have the right version of it." So `@vitejs/plugin-react@6` only works if vite 8 is already there.

Our repo is on `vite@7.3.6`. So when CI ran `npm ci`, npm looked at what the plugin needed, looked at what we actually had, and gave up:

```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: vite@7.3.6
npm error Could not resolve dependency:
npm error peer vite@"^8.0.0" from @vitejs/plugin-react@6.0.5
```

The upgrade isn't wrong. It's just incomplete. These two packages have to move up together, and Renovate split them into separate PRs.

## Why Renovate split them

Renovate already knows how to bundle related packages, and it does this a lot. That's why our other PRs have names like `major-eslint-monorepo`. But the rule it uses is **"do these ship from the same GitHub repo?"**

These two don't:

- `vite` ships from `vitejs/vite`
- `@vitejs/plugin-react` ships from `vitejs/vite-plugin-react`

Two different repos, so Renovate never connected them. It can't see the peer dependency that ties them together. The `@vitejs/` prefix makes them *look* like one family, but that's just a naming convention, not something Renovate reads.

## The fix

One new rule in `renovate.json` that tells Renovate to treat these as one unit:

```json
{
  "matchPackageNames": ["vite", "@vitejs/**"],
  "groupName": "vite"
}
```

Now vite and any `@vitejs/*` plugin get bundled into a single PR. Both versions move at the same time, npm is happy, and CI can actually pass.

The `**` at the end is a wildcard. It catches any `@vitejs/` package, so if someone adds `@vitejs/plugin-vue` later, it gets grouped too without anyone touching this file.

## What happens next

Once this merges, Renovate will close #486 on its next run and open a fresh PR carrying vite and the plugin together. That one should go green.

## What this does not change

I left the other packages alone on purpose.

You might notice eslint has plugins with peer dependencies too, and wonder why those aren't grouped here. The eslint 10 upgrade (#482) passed CI and already merged, so those peer ranges happen to line up fine. Adding a group has a real cost: Renovate closes the existing PR and refiles it. There was no reason to throw away a passing upgrade to fix a problem that isn't happening.

If eslint or TypeScript break this same way later, the fix is another rule shaped exactly like this one.